### PR TITLE
Add a generate uuid tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.5.2",
     "css-loader": "^0.23.1",
-    "electron-prebuilt": "^0.36.9",
+    "electron-prebuilt": "^0.37.8",
     "less": "^2.6.0",
     "less-loader": "^2.2.2",
     "less-plugin-autoprefix": "^1.5.1",
@@ -38,7 +38,7 @@
   "dependencies": {
     "mithril": "^0.2.3",
     "node-uuid": "^1.4.7",
-    "ramda": "^0.20.1",
+    "ramda": "^0.21.0",
     "redux": "^3.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "mithril": "^0.2.3",
+    "node-uuid": "^1.4.7",
     "ramda": "^0.20.1",
     "redux": "^3.3.1"
   }

--- a/src/lib/actionDispatch.js
+++ b/src/lib/actionDispatch.js
@@ -1,0 +1,5 @@
+export default function actionDispatch(action) {
+  return function(dispatch, data) {
+    return dispatch(action(data))
+  }
+}

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -5,9 +5,28 @@ import menus  from './menus'
 
 import sendToChannel from '../lib/sendToChannel'
 
-const { app, BrowserWindow, Menu } = electron
+import { v4 } from 'node-uuid'
+
+const { app, BrowserWindow, Menu, ipcMain } = electron
 
 const html = path.join(__dirname, '../../', 'index.html')
+const thunk = fn => () => fn()
+
+function generateUUID(fn, num) {
+  return Array(parseInt(num)).fill(null).map(fn)
+}
+
+ipcMain.on('task', (e, data) => {
+  const { type } = data
+  const send = sendToChannel(e.sender, type)
+
+  switch(type) {
+    case 'uuid':
+      const { num } = data
+      send(generateUUID(thunk(v4), num))
+      break
+  }
+})
 
 app.on('window-all-closed', () => {
   if(process.platform !== 'darwin') {

--- a/src/render/js/actions.js
+++ b/src/render/js/actions.js
@@ -1,5 +1,6 @@
-export const NAVIGATE = 'NAVIGATE'
-export const UUID_ADD = 'UUID_ADD'
+export const NAVIGATE     = 'NAVIGATE'
+export const UUID_ADD     = 'UUID_ADD'
+export const UUID_DELETE  = 'UUID_DELETE'
 
 export function navigate(currentPage) {
   return {
@@ -12,5 +13,12 @@ export function addUuid(uuids) {
   return {
     type: UUID_ADD,
     uuids
+  }
+}
+
+export function deleteUuid(index) {
+  return {
+    type: UUID_DELETE,
+    index
   }
 }

--- a/src/render/js/actions.js
+++ b/src/render/js/actions.js
@@ -1,8 +1,16 @@
 export const NAVIGATE = 'NAVIGATE'
+export const UUID_ADD = 'UUID_ADD'
 
 export function navigate(currentPage) {
   return {
-    type: 'NAVIGATE',
+    type: NAVIGATE,
     currentPage
+  }
+}
+
+export function addUuid(uuids) {
+  return {
+    type: UUID_ADD,
+    uuids
   }
 }

--- a/src/render/js/app.js
+++ b/src/render/js/app.js
@@ -2,7 +2,7 @@ import m, { mount } from 'mithril'
 import electron     from 'electron'
 
 import store        from './store'
-import { navigate } from './actions'
+import { navigate, addUuid } from './actions'
 
 import AppLayout from './components/AppLayout'
 
@@ -10,6 +10,11 @@ const { ipcRenderer } = electron
 
 ipcRenderer.on('navigate', function(sender, data) {
   store.dispatch(navigate(data))
+  m.redraw()
+})
+
+ipcRenderer.on('uuid', (e, data) => {
+  store.dispatch(addUuid(data))
   m.redraw()
 })
 

--- a/src/render/js/components/AppLayout.js
+++ b/src/render/js/components/AppLayout.js
@@ -2,7 +2,8 @@ import m from 'mithril'
 
 import { connect } from '../store'
 
-import SidebarNavs from './SidebarNavs'
+import SidebarNavs  from './SidebarNavs'
+import GenerateUUID from './GenerateUUID'
 
 function view(ctrl, attrs) {
   return (
@@ -11,7 +12,7 @@ function view(ctrl, attrs) {
         <h2 className="sidebar__header">WebDev-Multitool</h2>
         <SidebarNavs { ...attrs } />
       </div>
-      <div data-region="workspace"></div>
+      <GenerateUUID {...attrs } />
     </div>
   )
 }

--- a/src/render/js/components/GenerateUUID.js
+++ b/src/render/js/components/GenerateUUID.js
@@ -1,0 +1,34 @@
+import m from 'mithril'
+
+function controller(attrs) {
+  const num = m.prop('')
+  return { num }
+}
+
+function view(ctrl, attrs) {
+  const { num } = ctrl
+
+  return (
+    <div className="workspace">
+      <div className="uuid">
+        <div className="uuid__entry form--inline">
+          <label className="label">
+            <span className="label__text">Number:</span>
+            <input  className="text"
+                    size="3"
+                    maxlength="3"
+                    onchange={m.withAttr('value', num)}
+                    value={num()}
+            />
+          </label>
+          <button className="button uuid__button" type="button">Generate</button>
+        </div>
+        <div className="uuid__results">Results</div>
+      </div>
+    </div>
+  )
+}
+
+const GenerateUUID = { view, controller }
+
+export default GenerateUUID

--- a/src/render/js/components/GenerateUUID.js
+++ b/src/render/js/components/GenerateUUID.js
@@ -3,6 +3,8 @@ import { ipcRenderer } from 'electron'
 
 import sendToChannel from '../../../lib/sendToChannel'
 
+import UuidItem from './UuidItem'
+
 const sendTask    = sendToChannel(ipcRenderer, 'task')
 const requestUUID = fn => prop => () => fn({ type: 'uuid', num: prop() })
 
@@ -16,7 +18,8 @@ function controller(attrs) {
 
 function view(ctrl, attrs) {
   const { num, request } = ctrl
-  console.log(attrs);
+  const { uuids } = attrs
+  const results = uuids || []
 
   return (
     <div className="workspace">
@@ -38,7 +41,9 @@ function view(ctrl, attrs) {
             onclick={request}
           >Generate</button>
         </div>
-        <div className="uuid__results">Results</div>
+        <ul className="uuid__results">
+          {results.map(uuid => <UuidItem uuid={uuid} />)}
+        </ul>
       </div>
     </div>
   )

--- a/src/render/js/components/GenerateUUID.js
+++ b/src/render/js/components/GenerateUUID.js
@@ -8,6 +8,14 @@ import UuidItem from './UuidItem'
 const sendTask    = sendToChannel(ipcRenderer, 'task')
 const requestUUID = fn => prop => () => fn({ type: 'uuid', num: prop() })
 
+function mapItems(Comp, attrs) {
+  const { dispatch } = attrs
+
+  return function(uuid, index) {
+    return <Comp dispatch={dispatch} index={index} uuid={uuid} />
+  }
+}
+
 
 function controller(attrs) {
   const num     = m.prop('')
@@ -18,7 +26,7 @@ function controller(attrs) {
 
 function view(ctrl, attrs) {
   const { num, request } = ctrl
-  const { uuids } = attrs
+  const { uuids, dispatch } = attrs
   const results = uuids || []
 
   return (
@@ -42,7 +50,7 @@ function view(ctrl, attrs) {
           >Generate</button>
         </div>
         <ul className="uuid__results">
-          {results.map(uuid => <UuidItem uuid={uuid} />)}
+          {results.map(mapItems(UuidItem, { dispatch }))}
         </ul>
       </div>
     </div>

--- a/src/render/js/components/GenerateUUID.js
+++ b/src/render/js/components/GenerateUUID.js
@@ -6,7 +6,7 @@ import sendToChannel from '../../../lib/sendToChannel'
 import UuidItem from './UuidItem'
 
 const sendTask    = sendToChannel(ipcRenderer, 'task')
-const requestUUID = fn => prop => () => fn({ type: 'uuid', num: prop() })
+const requestUUID = (fn, prop) => () => fn({ type: 'uuid', num: prop() })
 
 function mapItems(Comp, attrs) {
   const { dispatch } = attrs
@@ -16,10 +16,9 @@ function mapItems(Comp, attrs) {
   }
 }
 
-
 function controller(attrs) {
   const num     = m.prop('')
-  const request = requestUUID(sendTask)(num)
+  const request = requestUUID(sendTask, num)
 
   return { num, request }
 }

--- a/src/render/js/components/GenerateUUID.js
+++ b/src/render/js/components/GenerateUUID.js
@@ -1,12 +1,22 @@
 import m from 'mithril'
+import { ipcRenderer } from 'electron'
+
+import sendToChannel from '../../../lib/sendToChannel'
+
+const sendTask    = sendToChannel(ipcRenderer, 'task')
+const requestUUID = fn => prop => () => fn({ type: 'uuid', num: prop() })
+
 
 function controller(attrs) {
-  const num = m.prop('')
-  return { num }
+  const num     = m.prop('')
+  const request = requestUUID(sendTask)(num)
+
+  return { num, request }
 }
 
 function view(ctrl, attrs) {
-  const { num } = ctrl
+  const { num, request } = ctrl
+  console.log(attrs);
 
   return (
     <div className="workspace">
@@ -14,14 +24,19 @@ function view(ctrl, attrs) {
         <div className="uuid__entry form--inline">
           <label className="label">
             <span className="label__text">Number:</span>
-            <input  className="text"
-                    size="3"
-                    maxlength="3"
-                    onchange={m.withAttr('value', num)}
-                    value={num()}
+            <input
+              className="text"
+              size="3"
+              maxlength="3"
+              onchange={m.withAttr('value', num)}
+              value={num()}
             />
           </label>
-          <button className="button uuid__button" type="button">Generate</button>
+          <button
+            className="button uuid__button"
+            type="button"
+            onclick={request}
+          >Generate</button>
         </div>
         <div className="uuid__results">Results</div>
       </div>

--- a/src/render/js/components/UuidItem.js
+++ b/src/render/js/components/UuidItem.js
@@ -3,14 +3,16 @@ import { clipboard } from 'electron'
 
 import { deleteUuid } from '../actions'
 
+import actionDispatch from '../../../lib/actionDispatch'
+
 const copyItem    = (clip, uuid) => () => clip.writeText(uuid)
-const deleteItem  = (dispatch, action, index) => () => dispatch(action(index))
+const deleteItem  = actionDispatch(deleteUuid)
 
 function controller(attrs) {
   const { uuid, dispatch, index } = attrs
 
   const copy    = copyItem(clipboard, uuid)
-  const remove  = deleteItem(dispatch, deleteUuid, index)
+  const remove  = deleteItem(dispatch, index)
 
   return { copy, remove }
 }

--- a/src/render/js/components/UuidItem.js
+++ b/src/render/js/components/UuidItem.js
@@ -1,19 +1,41 @@
 import m from 'mithril'
+import { clipboard } from 'electron'
+
+import { deleteUuid } from '../actions'
+
+const copyItem    = (clip, uuid) => () => clip.writeText(uuid)
+const deleteItem  = (dispatch, action, index) => () => dispatch(action(index))
+
+function controller(attrs) {
+  const { uuid, dispatch, index } = attrs
+
+  const copy    = copyItem(clipboard, uuid)
+  const remove  = deleteItem(dispatch, deleteUuid, index)
+
+  return { copy, remove }
+}
 
 function view(ctrl, attrs) {
   const { uuid } = attrs
+  const { copy, remove } = ctrl
 
   return (
     <li className="uuid__item">
       <span className="uuid__uuid">{uuid}</span>
       <div className="uuid__buttons form--inline">
-        <button className="button" type="button">Copy</button>
-        <button className="button" type="button">Delete</button>
+        <button
+          className="button"
+          onclick={copy}
+          type="button">Copy</button>
+        <button
+          className="button"
+          onclick={remove}
+          type="button">Delete</button>
       </div>
     </li>
   )
 }
 
-const UuidItem = { view }
+const UuidItem = { controller, view }
 
 export default UuidItem

--- a/src/render/js/components/UuidItem.js
+++ b/src/render/js/components/UuidItem.js
@@ -1,0 +1,19 @@
+import m from 'mithril'
+
+function view(ctrl, attrs) {
+  const { uuid } = attrs
+
+  return (
+    <li className="uuid__item">
+      <span className="uuid__uuid">{uuid}</span>
+      <div className="uuid__buttons form--inline">
+        <button className="button" type="button">Copy</button>
+        <button className="button" type="button">Delete</button>
+      </div>
+    </li>
+  )
+}
+
+const UuidItem = { view }
+
+export default UuidItem

--- a/src/render/js/store.js
+++ b/src/render/js/store.js
@@ -2,13 +2,18 @@ import m from 'mithril'
 
 import { createStore } from 'redux'
 
-import { NAVIGATE } from './actions'
+import { NAVIGATE, UUID_ADD } from './actions'
 
 function reducer(state={}, action) {
   switch(action.type) {
     case NAVIGATE:
       const { currentPage } = action
       return Object.assign({}, state, { currentPage })
+    case UUID_ADD:
+      const { uuids } = action
+      const oldList   = state.uuids || []
+
+      return Object.assign({}, state, { uuids: oldList.concat(uuids) })
   }
   return state
 }

--- a/src/render/js/store.js
+++ b/src/render/js/store.js
@@ -2,18 +2,32 @@ import m from 'mithril'
 
 import { createStore } from 'redux'
 
-import { NAVIGATE, UUID_ADD } from './actions'
+import {
+  NAVIGATE,
+  UUID_ADD,
+  UUID_DELETE
+} from './actions'
 
 function reducer(state={}, action) {
   switch(action.type) {
     case NAVIGATE:
       const { currentPage } = action
       return Object.assign({}, state, { currentPage })
+
     case UUID_ADD:
       const { uuids } = action
-      const oldList   = state.uuids || []
+      const oldList = state.uuids || []
 
       return Object.assign({}, state, { uuids: oldList.concat(uuids) })
+
+    case UUID_DELETE:
+      const { index } = action
+
+      const result = state.uuids
+        .slice(0, index)
+        .concat(state.uuids.slice(index + 1))
+
+      return Object.assign({}, state, { uuids: result })
   }
   return state
 }

--- a/src/render/less/main.less
+++ b/src/render/less/main.less
@@ -17,10 +17,10 @@
 
 .base-input {
   .spacing(0.5rem, 1rem);
-  font-size: inherit;
-  outline: none;
-  border: 3px solid;
-  border-radius: 7px;
+  font-size:  inherit;
+  outline:    none;
+  border:     3px solid;
+  border-radius:  7px;
 }
 
 .button {

--- a/src/render/less/main.less
+++ b/src/render/less/main.less
@@ -4,3 +4,54 @@
 @import 'utility/all';
 
 @import 'components/all';
+
+.form--inline {
+  & > * {
+    margin-left: 1rem;
+  }
+
+  &:first-child {
+    margin-left: 0;
+  }
+}
+
+.base-input {
+  .spacing(0.5rem, 1rem);
+  font-size: inherit;
+  outline: none;
+  border: 3px solid;
+  border-radius: 7px;
+}
+
+.button {
+  .base-input;
+  cursor: pointer;
+}
+
+.text {
+  .base-input;
+}
+
+.label {
+  &__text {
+    margin-right: 1rem;
+  }
+}
+
+.workspace {
+  margin-left: 30rem;
+  padding: 2rem;
+}
+
+.uuid {
+  .deci;
+
+  &__entry {
+    .spacing(2rem);
+    text-align: center;
+  }
+
+  &__results {
+    .bg-green;
+  }
+}

--- a/src/render/less/main.less
+++ b/src/render/less/main.less
@@ -52,6 +52,29 @@
   }
 
   &__results {
-    .bg-green;
+    list-style: none;
+    max-width:  60rem;
+    margin:     0 auto;
+  }
+
+  &__item {
+    .row;
+    .spacing(1rem);
+    border-radius:  5px;
+    align-items:    center;
+    font-size:      initial;
+
+    &:nth-child(odd) {
+      .bg-green;
+    }
+  }
+
+  &__uuid {
+    flex: 1;
+    margin-left: 2rem;
+  }
+
+  &__buttons {
+    .deci;
   }
 }


### PR DESCRIPTION
![](https://img.buzzfeed.com/buzzfeed-static/static/2015-04/21/10/enhanced/webdr01/anigif_enhanced-23916-1429625127-2.gif)

This PR adds the first attempt at handling the IPC between the render and main process. Implemented the start of the GenerateUUID tool.

This PR does the following:
- Adds a `node-uuid` dependency.
- Set up a `task` channel on the mainIPC for handling tool requests
- Adds code on main to generate a given number of UUIDs
- Adds `UUID_ADD` and `UUID_DELETE` actions
- Adds required reducers to add and delete UUIDs
- Add GenerateUUID  and UuidItem components
- Provided some :pig: styles to start with.
