### PR TITLE
Add some better usability to the UUID tool

### DIFF
--- a/src/lib/render/actionDispatch.js
+++ b/src/lib/render/actionDispatch.js
@@ -1,3 +1,8 @@
-export default function actionDispatch(action) {
-  return (dispatch, data) => () => dispatch(action(data))
-}
+import curry    from 'ramda/src/curry'
+import compose  from 'ramda/src/compose'
+
+const actionDispatch = curry(
+  (action, dispatch, data) => () => compose(dispatch, action)(data)
+)
+
+export default actionDispatch

--- a/src/render/js/components/GenerateUuid.js
+++ b/src/render/js/components/GenerateUuid.js
@@ -1,12 +1,7 @@
 import m from 'mithril'
-import { ipcRenderer } from 'electron'
 
-import sendToChannel from 'shared/sendToChannel'
-
-import UuidItem from './UuidItem'
-
-const sendTask    = sendToChannel(ipcRenderer, 'task')
-const requestUUID = (fn, prop) => () => fn({ type: 'uuid', num: prop() })
+import UuidItem   from './UuidItem'
+import UuidEntry  from './UuidEntry'
 
 function mapItems(Comp, attrs) {
   const { dispatch } = attrs
@@ -16,37 +11,13 @@ function mapItems(Comp, attrs) {
   }
 }
 
-function controller(attrs) {
-  const num     = m.prop('')
-  const request = requestUUID(sendTask, num)
-
-  return { num, request }
-}
-
 function view(ctrl, attrs) {
-  const { num, request } = ctrl
   const { uuids, dispatch } = attrs
   const results = uuids || []
 
   return (
     <div className="uuid">
-      <div className="uuid__entry form--inline">
-        <label className="label">
-          <span className="label__text">Number:</span>
-          <input
-            className="text"
-            size="3"
-            maxlength="3"
-            onchange={m.withAttr('value', num)}
-            value={num()}
-          />
-        </label>
-        <button
-          className="button uuid__button"
-          type="button"
-          onclick={request}
-        >Generate</button>
-      </div>
+      <UuidEntry dispatch={dispatch} />
       <ul className="uuid__results">
         {results.map(mapItems(UuidItem, { dispatch }))}
       </ul>
@@ -54,6 +25,6 @@ function view(ctrl, attrs) {
   )
 }
 
-const GenerateUUID = { view, controller }
+const GenerateUUID = { view }
 
 export default GenerateUUID

--- a/src/render/js/components/UuidEntry.js
+++ b/src/render/js/components/UuidEntry.js
@@ -1,0 +1,55 @@
+import m                from 'mithril'
+import { ipcRenderer }  from 'electron'
+
+import sendToChannel  from 'shared/sendToChannel'
+import actionDispatch from 'render/actionDispatch'
+
+import { clearUuid } from 'actions/uuid'
+
+const sendTask    = sendToChannel(ipcRenderer, 'task')
+const requestUUID = (fn, prop) => () => fn({ type: 'uuid', num: prop() })
+
+const clearUuids = actionDispatch(clearUuid)
+
+function controller(attrs) {
+  const { dispatch } = attrs
+
+  const num     = m.prop('')
+  const request = requestUUID(sendTask, num)
+  const clear   = clearUuids(dispatch, null)
+
+  return { num, request, clear }
+}
+
+function view(ctrl) {
+  const { num, request, clear } = ctrl
+
+  return (
+    <div className="uuid__entry form--inline">
+      <label className="label">
+        <span className="label__text">Number:</span>
+        <input
+          className="text"
+          size="3"
+          maxlength="3"
+          onchange={m.withAttr('value', num)}
+          value={num()}
+        />
+      </label>
+      <button
+        className="button uuid__button"
+        type="button"
+        onclick={request}
+      >Generate</button>
+      <button
+        className="button uuid__button"
+        type="button"
+        onclick={clear}
+      >Clear</button>
+    </div>
+  )
+}
+
+const UuidEntry = { view, controller }
+
+export default UuidEntry

--- a/src/render/js/components/UuidItem.js
+++ b/src/render/js/components/UuidItem.js
@@ -3,42 +3,38 @@ import { clipboard } from 'electron'
 
 import compose from 'ramda/src/compose'
 
-import concatIf       from 'shared/concatIf'
 import actionDispatch from 'render/actionDispatch'
 
 import { deleteUuid } from 'actions/uuid'
 
-const texttoClip = clip => uuid => () => clip.writeText(uuid)
-
+const texttoClip  = clip => uuid => () => clip.writeText(uuid)
 const copyItem    = texttoClip(clipboard)
+
 const deleteItem  = actionDispatch(deleteUuid)
 
 function controller(attrs) {
-  const { uuid, dispatch, index } = attrs
-  const remove = deleteItem(dispatch, index)
+  const { dispatch } = attrs
+  const remove = deleteItem(dispatch)
 
   return { copyItem, remove }
 }
 
 function view(ctrl, attrs) {
-  const { uuid } = attrs
-  const { copyItem, remove } = ctrl
+  const { index } = attrs
+  const { uuid }  = attrs.uuid
 
-  const used    = concatIf('uuid__item--used', uuid.used)
-  const classes = used([ 'uuid__item' ]).join(' ')
+  const { remove, copyItem } = ctrl
+
+  const useUuid = compose(remove(index), copyItem(uuid))
 
   return (
-    <li className={classes}>
-      <span className="uuid__uuid">{uuid.uuid}</span>
+    <li className="uuid__item">
+      <span className="uuid__uuid">{uuid}</span>
       <div className="uuid__buttons form--inline">
         <button
           className="button"
-          onclick={copyItem(uuid.uuid)}
-          type="button">Copy</button>
-        <button
-          className="button"
-          onclick={remove}
-          type="button">Delete</button>
+          onclick={useUuid}
+          type="button">Use</button>
       </div>
     </li>
   )

--- a/src/render/js/components/UuidItem.js
+++ b/src/render/js/components/UuidItem.js
@@ -1,5 +1,5 @@
-import m from 'mithril'
-import { clipboard } from 'electron'
+import m              from 'mithril'
+import { clipboard }  from 'electron'
 
 import compose from 'ramda/src/compose'
 

--- a/src/render/js/store/actions/uuid.js
+++ b/src/render/js/store/actions/uuid.js
@@ -1,5 +1,6 @@
-export const UUID_ADD       = 'UUID_ADD'
-export const UUID_DELETE    = 'UUID_DELETE'
+export const UUID_ADD     = 'UUID_ADD'
+export const UUID_DELETE  = 'UUID_DELETE'
+export const UUID_CLEAR   = 'UUID_CLEAR'
 
 export function addUuid(uuids) {
   return {
@@ -12,5 +13,11 @@ export function deleteUuid(index) {
   return {
     type: UUID_DELETE,
     index
+  }
+}
+
+export function clearUuid() {
+  return {
+    type: UUID_CLEAR
   }
 }

--- a/src/render/js/store/store.js
+++ b/src/render/js/store/store.js
@@ -4,7 +4,8 @@ import { createStore, applyMiddleware } from 'redux'
 
 import {
   UUID_ADD,
-  UUID_DELETE
+  UUID_DELETE,
+  UUID_CLEAR
 } from 'actions/uuid'
 
 function redraw() {
@@ -32,6 +33,9 @@ function reducer(state={}, action) {
         .concat(state.uuids.slice(index + 1))
 
       return Object.assign({}, state, { uuids: result })
+
+    case UUID_CLEAR:
+      return Object.assign({}, state, { uuids: [] })
   }
   return state
 }

--- a/src/render/js/store/store.js
+++ b/src/render/js/store/store.js
@@ -1,17 +1,20 @@
 import m from 'mithril'
 
-import { createStore } from 'redux'
+import { createStore, applyMiddleware } from 'redux'
 
 import {
   UUID_ADD,
   UUID_DELETE
 } from 'actions/uuid'
 
-import lensIndex  from 'ramda/src/lensIndex'
-import lensProp   from 'ramda/src/lensProp'
-import over       from 'ramda/src/over'
-import assoc      from 'ramda/src/assoc'
-import compose    from 'ramda/src/compose'
+function redraw() {
+  return (next) => (action) => {
+    m.startComputation()
+    const result = next(action)
+    m.endComputation()
+    return result
+  }
+}
 
 function reducer(state={}, action) {
   const { index } = action
@@ -33,7 +36,7 @@ function reducer(state={}, action) {
   return state
 }
 
-const store = createStore(reducer)
+const store = createStore(reducer, {}, applyMiddleware(redraw))
 
 export function connect(Component) {
   return {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,8 @@ module.exports = {
   context: paths.src,
   target: 'electron',
   entry:   './js',
+  debug: true,
+  devtool: '#eval-source-map',
   output: {
     filename:       'bundle.js',
     library:        'WebApp',


### PR DESCRIPTION
## Harder Better Faster

![](http://img-comment-fun.9cache.com/media/ag3BpB6/aGjpKGEL_700wa_0.gif)

This PR just adds some better usability features also a wee bit of cleanup

To do this we do the following:
- Make `actionDispatch` a bit more functional :lipstick: 
- Move `UuidEntry` bits into their own file for fun and excitement. :lipstick: 
- Add redux bits for handling a `UUID_CLEAR` action :sparkles:
- Add a clear button to dispatch the new `UUID_CLEAR` action in `UuidEntry` :sparkles: 
- moved the delete and copy buttons into a brand new Use button that combines those two actions. :sparkles: 
- Clean up some dead code in the store :sparkles: 
- Added the source maps to webpack bundle. :moneybag: 
- Added a Redux Middleware to ensuring that we are rendering as expected. :moneybag: 
