### PR TITLE
Remove GenUuid Use Button and make GenUuid the provider

### DIFF
--- a/src/lib/shared/helpers.js
+++ b/src/lib/shared/helpers.js
@@ -1,17 +1,21 @@
-import _compose from 'ramda/src/compose'
-import _curry   from 'ramda/src/curry'
-import _prop    from 'ramda/src/prop'
-import _objOf   from 'ramda/src/objOf'
-import _map     from 'ramda/src/map'
-import _always  from 'ramda/src/always'
+import _compose   from 'ramda/src/compose'
+import _curry     from 'ramda/src/curry'
+import _prop      from 'ramda/src/prop'
+import _pick      from 'ramda/src/pick'
+import _objOf     from 'ramda/src/objOf'
+import _map       from 'ramda/src/map'
+import _always    from 'ramda/src/always'
+import _defaultTo from 'ramda/src/defaultTo'
 
 export const compose  = _compose
 export const curry    = _curry
 
-export const id       = x => x
-export const always   = _always
-export const prop     = _prop
-export const objOf    = _objOf
+export const id         = x => x
+export const always     = _always
+export const prop       = _prop
+export const pick       = _pick
+export const objOf      = _objOf
+export const defaultTo  = _defaultTo
 
 // Pointfree
 export const map = _map

--- a/src/render/js/components/AppLayout.js
+++ b/src/render/js/components/AppLayout.js
@@ -5,8 +5,6 @@ import {
   ipcRenderer
 } from 'electron'
 
-import { connect } from 'store'
-
 import GenerateUuid from './GenerateUuid'
 
 import sendToChannel  from 'shared/sendToChannel'
@@ -17,14 +15,11 @@ const sendTask = sendToChannel(ipcRenderer, 'task')
 function view(ctrl, attrs) {
   return (
     <div>
-      <GenerateUuid
-        copyText={copyText}
-        sendTask={sendTask}
-        {...attrs } />
+      <GenerateUuid copyText={copyText} sendTask={sendTask} />
     </div>
   )
 }
 
-const AppLayout = connect({ view })
+const AppLayout = { view }
 
 export default AppLayout

--- a/src/render/js/components/GenerateUuid.js
+++ b/src/render/js/components/GenerateUuid.js
@@ -1,11 +1,20 @@
 import m from 'mithril'
 
+import { connect } from 'store'
+
 import {
   clearUuid,
   deleteUuid
 } from 'actions/uuid'
 
-import { curry, compose, prop, always } from 'shared/helpers'
+import {
+  curry,
+  compose,
+  prop,
+  always,
+  pick,
+  defaultTo
+} from 'shared/helpers'
 
 import actionDispatch from 'render/actionDispatch'
 
@@ -44,6 +53,8 @@ function view(ctrl, attrs) {
   )
 }
 
-const GenerateUUID = { view, controller }
+const qry = compose(defaultTo({}), pick(['uuids']))
+
+const GenerateUUID = connect({ view, controller }, qry)
 
 export default GenerateUUID

--- a/src/render/js/components/UuidItem.js
+++ b/src/render/js/components/UuidItem.js
@@ -7,14 +7,8 @@ function view(ctrl, attrs) {
   const useUuid = () => use({index, uuid})
 
   return (
-    <li className="uuid__item">
+    <li className="uuid__item" onclick={useUuid}>
       <span className="uuid__uuid">{uuid}</span>
-      <div className="uuid__buttons">
-        <button
-          className="button"
-          onclick={useUuid}
-          type="button">Use</button>
-      </div>
     </li>
   )
 }

--- a/src/render/js/store/store.js
+++ b/src/render/js/store/store.js
@@ -1,6 +1,7 @@
 import m from 'mithril'
 
 import { createStore, applyMiddleware } from 'redux'
+import { id } from 'shared/helpers'
 
 import {
   UUID_ADD,
@@ -42,12 +43,17 @@ function reducer(state={}, action) {
 
 const store = createStore(reducer, {}, applyMiddleware(redraw))
 
-export function connect(Component) {
+export function connect(Component, qry=id) {
   return {
-    view() {
-      const state = store.getState()
+    view(ctrl, attrs) {
+      const state = qry(store.getState())
+
       return (
-        <Component dispatch={store.dispatch} {...state}/>
+        <Component
+          dispatch={store.dispatch}
+          {...state}
+          {...attrs}
+        />
       )
     }
   }

--- a/src/render/less/components/uuid.less
+++ b/src/render/less/components/uuid.less
@@ -8,13 +8,14 @@
 
   &__results {
     list-style: none;
-    max-width:  60rem;
+    max-width:  50rem;
     margin:     0 auto;
   }
 
   &__item {
     .row;
     .spacing(1rem);
+    cursor:         pointer;
     border-radius:  5px;
     align-items:    center;
     font-size:      initial;
@@ -27,9 +28,6 @@
   &__uuid {
     flex: 1;
     margin-left: 2rem;
-  }
-
-  &__buttons {
-    .deci;
+    text-align: center;
   }
 }


### PR DESCRIPTION
## Provider of all dat rainbow

![](http://cnl.h.cdn.cosmopolitan.nl/assets/15/38/1442394228-1.gif)

This PR does the following:
- Remove the use button and move that functionality to the item.

:tada: :boom: **BONUS** :boom: :tada:
- Add the ability to allow Providers to query state on connect.
- Moved the Provider responsibility from the `AppLayout` to the `GennerateUuid`
- Add some Julia Stylez :lipstick: 
- Add some additional helper (`defaultTo`, `pick`)
